### PR TITLE
fix: Ignore patterns [WIP]

### DIFF
--- a/src/helpers/global.helper.ts
+++ b/src/helpers/global.helper.ts
@@ -210,12 +210,38 @@ const prepareIgnored = (
   ignored: string | string[],
   outDir: string = OUT_DIR
 ): string[] | undefined => {
-  let ignore: string[] | undefined;
-  if (ignored) {
-    ignore = Array.isArray(ignored) ? ignored : [ignored];
-    ignore = ignore.map((ignoredPage) => `${outDir}/${ignoredPage}`);
+  if (!ignored) return undefined;
+
+  const list = Array.isArray(ignored) ? ignored : [ignored];
+  const patterns = new Set<string>();
+
+  for (const raw of list) {
+    if (!raw) continue;
+
+    // Normalise: drop leading/trailing slashes so `/test`, `test/` and `test`
+    // all behave the same way.
+    const entry = raw.replace(/^\/+/, '').replace(/\/+$/, '');
+    if (!entry) continue;
+
+    const prefixed = `${outDir}/${entry}`;
+
+    // Keep the user's pattern as-is. For a folder name this ignores everything
+    // inside the folder (e.g. `build/test/index.html`).
+    patterns.add(prefixed);
+
+    // Explicitly ignore everything nested under the route folder.
+    patterns.add(`${prefixed}/**`);
+
+    // Also ignore the flat html file for this route. With `trailingSlash: false`
+    // (the SvelteKit default) a route like `/test` or a `404` fallback is built
+    // as `build/test.html` / `build/404.html`, which the bare folder pattern
+    // above does NOT match. Without this, `-i 404` / `-i test` had no effect.
+    if (!entry.endsWith('.html')) {
+      patterns.add(`${prefixed}.html`);
+    }
   }
-  return ignore;
+
+  return patterns.size ? [...patterns] : undefined;
 };
 
 const prepareChangeFreq = (options: Options): ChangeFreq => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -338,6 +338,51 @@ test('Sitemap ignore Page1', async () => {
     ])
   );
 });
+
+// Regression: with `trailingSlash: false` (the SvelteKit default) routes are
+// built as flat `name.html` files. A `404` fallback or a `/test` route then
+// lives at `build/404.html` / `build/test.html`, which the bare folder ignore
+// pattern did not match. See GitHub issue about `-i 404` / `-i test`.
+test('Sitemap ignore flat html route (trailing slash false)', async () => {
+  const json = await prepareData('https://example.com', {
+    ...optionsTest,
+    ignore: 'flat',
+    debug: true
+  });
+
+  const pages = json.map((item) => item.page);
+  expect(pages).not.toContain('https://example.com/flat');
+  expect(pages).toContain('https://example.com');
+  expect(pages).toContain('https://example.com/page1');
+});
+
+test('Sitemap ignore flat html route with leading slash', async () => {
+  const json = await prepareData('https://example.com', {
+    ...optionsTest,
+    ignore: '/flat',
+    debug: true
+  });
+
+  const pages = json.map((item) => item.page);
+  expect(pages).not.toContain('https://example.com/flat');
+  expect(pages).toContain('https://example.com');
+});
+
+test('Sitemap ignore array of flat file and folder', async () => {
+  const json = await prepareData('https://example.com', {
+    ...optionsTest,
+    ignore: ['flat', 'page1'],
+    debug: true
+  });
+
+  const pages = json.map((item) => item.page);
+  expect(pages).not.toContain('https://example.com/flat');
+  expect(pages).not.toContain('https://example.com/page1');
+  expect(pages).not.toContain('https://example.com/page1/flat1');
+  expect(pages).not.toContain('https://example.com/page1/subpage1');
+  expect(pages).toContain('https://example.com/page2');
+});
+
 describe('Trailing slashes', () => {
   test('Add trailing slashes', async () => {
     const json = await prepareData('https://example.com/', {


### PR DESCRIPTION
### Issue #54
`--ignore` had no effect on certain routes. 

### Reported cases
`-i 404` (with a `404.html` fallback), `-i test`, and any project using SvelteKit's default `trailingSlash: false`.

### Cause
Ignored entries were only prefixed with the output dir, producing globs like `build/404`. A bare folder pattern matches a folder's *contents*, not the flat `build/404.html` file that `trailingSlash: false` builds produce — so those routes were never excluded.

### Fix
`prepareIgnored` now expands every entry into:

- `build/<entry>` — folder contents
- `build/<entry>/**` — nested files
- `build/<entry>.html` — the flat route file (previously missing)

Leading/trailing slashes are normalised, so `/test`, `test/` and `test` behave identically.

### Tests
Added regression tests in `tests/main.test.ts` covering a flat-file route, a leading-slash variant, and an array of mixed file/folder ignores.

Fixes #54